### PR TITLE
fix: make `SmolSet::retain` actually callable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolset"
-version = "1.3.1"
+version = "1.3.2-alpha"
 authors = ["Chris Fallin <cfallin@c1f.net>", "Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>"]
 description = """"
 An unordered set of elements optimized for small sizes.
@@ -8,6 +8,8 @@ This is a fork of the original library with overhauled internals, better fallbac
 """
 repository = "https://github.com/hbina/smolset"
 license = "MIT"
+
+publish = false
 
 [dependencies]
 smallvec = "1.6.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,10 +286,11 @@ where
     /// Removes all elements in the set that does not satisfy the given predicate `f`.
     pub fn retain<F>(&mut self, f: F)
     where
-        F: FnMut(&mut A::Item) -> bool + for<'r> FnMut(&'r <A as smallvec::Array>::Item) -> bool,
+        F: FnMut(&A::Item) -> bool,
     {
+        let mut f = f;
         match &mut self.inner {
-            InnerSmolSet::Stack(ref mut elements) => elements.retain(f),
+            InnerSmolSet::Stack(ref mut elements) => elements.retain(move |element| f(element)),
             InnerSmolSet::Heap(ref mut elements) => elements.retain(f),
         }
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -53,6 +53,29 @@ fn test_remove() {
 }
 
 #[test]
+fn test_retain() {
+    let mut s: SmolSet<[u32; 2]> = SmolSet::new();
+    assert_eq!(s.insert(1), true);
+    assert_eq!(s.insert(2), true);
+    assert_eq!(s.len(), 2);
+    assert!(s.contains(&1));
+    s.retain(|r| r != &1);
+    assert_eq!(s.len(), 1);
+    s.retain(|r| r != &1);
+    assert_eq!(s.len(), 1);
+    assert!(!s.contains(&1));
+    assert_eq!(s.insert(1), true);
+    let expected = vec![1, 2];
+    assert_eq!(s.len(), expected.len());
+    assert!(s
+        .iter()
+        .map(|r| *r)
+        .collect::<Vec<u32>>()
+        .iter()
+        .all(|x| expected.contains(x)));
+}
+
+#[test]
 fn test_clone() {
     let mut s: SmolSet<[u32; 2]> = SmolSet::new();
     s.insert(1);


### PR DESCRIPTION
the previous constraints on `F`, `fn(&mut _) -> _` and `for<'r> fn(&'r _) -> _`, couldn't both be satisfied at once.